### PR TITLE
Change: embed the main headings of all pages in header-elements

### DIFF
--- a/webclient/templates/main.html
+++ b/webclient/templates/main.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}BaNaNaS{% endblock %}</h1>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_new_package.html
+++ b/webclient/templates/manager_new_package.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}Upload new package{% endblock %}</h1>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_edit.html
+++ b/webclient/templates/manager_package_edit.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_info.html
+++ b/webclient/templates/manager_package_info.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_list.html
+++ b/webclient/templates/manager_package_list.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}Awesome content by {{ session.display_name }}{% endblock %}</h1>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_version_edit.html
+++ b/webclient/templates/manager_version_edit.html
@@ -1,8 +1,10 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
+<header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -1,8 +1,10 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
+<header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/package_list.html
+++ b/webclient/templates/package_list.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}{{ content_type }}{% endblock %}</h1>
+</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/tos-1.2.html
+++ b/webclient/templates/tos-1.2.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block header %}
+<header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
     <h3>Version 1.2, 2010-01-26</h3>
+</header>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -1,8 +1,10 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
+<header>
     <h1><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+</header>
 {% endblock %}
 {% block content %}
 


### PR DESCRIPTION
This change provides an additional bit of semantics. It makes it also easier to format the page header (including the sub headings) independent from the rest of the pages with only descendant selectors (i.e. with `header h1` or (if really necessary) `body > header h1`).

Additionally I want to replace the `h3` in the headers with `p`. Is it recommended to add a second (or amended) commit *here* or to deliver it in a separate PR? 

There is more in the pipeline but I want to split it into independent steps.