### PR TITLE
Change: <thead> and <tbody> for tables where suitable, <th> for row names

### DIFF
--- a/webclient/templates/manager_package_info.html
+++ b/webclient/templates/manager_package_info.html
@@ -9,49 +9,59 @@
 
 <a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/edit">Edit package meta data</a>
 <table>
-<tr><td>Content Id</td><td>{{ package["content-type"] }}/{{ package["unique-id"] }}</td></tr>
-<tr><td>Name</td><td>{{ package["name"] }}</td></tr>
-<tr><td>Project site</td><td>
-{% if package["url"] %}
-<a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
-{% endif %}
-</td></tr>
-<tr><td>Tags</td><td><ul>
-{% for t in package["tags"] %}
-    <li>{{ t }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Authors</td><td><ul>
-{% for a in package["authors"] %}
-    <li>{{ a["display-name"] }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Description</td><td>
+<tbody>
+    <tr><th>Content Id</th><td>{{ package["content-type"] }}/{{ package["unique-id"] }}</td></tr>
+    <tr><th>Name</th><td>{{ package["name"] }}</td></tr>
+    <tr><th>Project site</th><td>
+    {% if package["url"] %}
+        <a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
+    {% endif %}
+    </td></tr>
+    <tr><th>Tags</th><td>
+        <ul>
+        {% for t in package["tags"] %}
+            <li>{{ t }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Authors</th><td>
+        <ul>
+        {% for a in package["authors"] %}
+            <li>{{ a["display-name"] }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Description</th><td>
     {% for l in package["description"].splitlines() %}
-    {{ l }}<br/>
+        {{ l }}<br/>
     {% endfor %}
-</td></tr>
+    </td></tr>
+</tbody>
 </table>
 
 <table>
-<tr>
-    <th>Version</th>
-    <th>Upload date</th>
-    <th>MD5 (partial)</th>
-    <th>License</th>
-    <th>Availability</th>
-    <th>Edit meta data</th>
-</tr>
+<thead>
+    <tr>
+        <th>Version</th>
+        <th>Upload date</th>
+        <th>MD5 (partial)</th>
+        <th>License</th>
+        <th>Availability</th>
+        <th>Edit meta data</th>
+    </tr>
+</thead>
+<tbody>
 {% for version in package["versions"] %}
-<tr>
-    <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}">{{ version["version"] }}</a></td>
-    <td>{{ version["upload-date"] }}</td>
-    <td>{{ version["md5sum-partial"] }}</td>
-    <td>{{ version["license"] }}</td>
-    <td>{{ version["availability"] }}</td>
-    <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}/edit">Edit</a></td>
-</tr>
+    <tr>
+        <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}">{{ version["version"] }}</a></td>
+        <td>{{ version["upload-date"] }}</td>
+        <td>{{ version["md5sum-partial"] }}</td>
+        <td>{{ version["license"] }}</td>
+        <td>{{ version["availability"] }}</td>
+        <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}/edit">Edit</a></td>
+    </tr>
 {% endfor %}
+</tbody>
 </table>
 
 {% endblock %}

--- a/webclient/templates/manager_package_list.html
+++ b/webclient/templates/manager_package_list.html
@@ -7,46 +7,50 @@
 {% block content %}
 
 <table>
-<tr>
-    <th rowspan="2">Type</th>
-    <th rowspan="2">Id</th>
-    <th rowspan="2">Name</th>
-    <th colspan="3">All versions</th>
-    <th colspan="3">Versions for new games</th>
-    <th rowspan="2">Upload</th>
-</tr>
-<tr>
-    <th>Number</th>
-    <th>Latest version</th>
-    <th>Upload date</th>
-    <th>Number</th>
-    <th>Latest version</th>
-    <th>Upload date</th>
-</tr>
+<thead>
+    <tr>
+        <th rowspan="2">Type</th>
+        <th rowspan="2">Id</th>
+        <th rowspan="2">Name</th>
+        <th colspan="3">All versions</th>
+        <th colspan="3">Versions for new games</th>
+        <th rowspan="2">Upload</th>
+    </tr>
+    <tr>
+        <th>Number</th>
+        <th>Latest version</th>
+        <th>Upload date</th>
+        <th>Number</th>
+        <th>Latest version</th>
+        <th>Upload date</th>
+    </tr>
+</thead>
+<tbody>
 {% for package in packages %}
-<tr>
-    <td>{{ package["content-type"] }}</td>
-    <td>{{ package["unique-id"] }}</td>
-    <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ package["name"] }}</a></td>
-    <td>{{ package["num-all"] }}</td>
-    {% set latest = package["latest-all"] %}
-    {% if latest %}
-        <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ latest["upload-date"] }}">{{ latest["version"] }}</a></td>
-        <td>{{ latest["upload-date"] }}</td>
-    {% else %}
-        <td></td><td></td>
-    {% endif %}
-    <td>{{ package["num-newgame"] }}</td>
-    {% set latest = package["latest-newgame"] %}
-    {% if latest %}
-        <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ latest["upload-date"] }}">{{ latest["version"] }}</a></td>
-        <td>{{ latest["upload-date"] }}</td>
-    {% else %}
-        <td></td><td></td>
-    {% endif %}
-    <td><a href="/manager/new-package?unique-id={{ package["unique-id"] }}">Upload update</a></td>
-</tr>
+    <tr>
+        <td>{{ package["content-type"] }}</td>
+        <td>{{ package["unique-id"] }}</td>
+        <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ package["name"] }}</a></td>
+        <td>{{ package["num-all"] }}</td>
+        {% set latest = package["latest-all"] %}
+        {% if latest %}
+            <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ latest["upload-date"] }}">{{ latest["version"] }}</a></td>
+            <td>{{ latest["upload-date"] }}</td>
+        {% else %}
+            <td></td><td></td>
+        {% endif %}
+        <td>{{ package["num-newgame"] }}</td>
+        {% set latest = package["latest-newgame"] %}
+        {% if latest %}
+            <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ latest["upload-date"] }}">{{ latest["version"] }}</a></td>
+            <td>{{ latest["upload-date"] }}</td>
+        {% else %}
+            <td></td><td></td>
+        {% endif %}
+        <td><a href="/manager/new-package?unique-id={{ package["unique-id"] }}">Upload update</a></td>
+    </tr>
 {% endfor %}
+</tbody>
 </table>
 <a href="/manager/new-package">Upload new content</a>
 

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -10,52 +10,62 @@
 
 <a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}/edit">Edit version meta data</a>
 <table>
-<tr><td>Content Id</td><td>{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["md5sum-partial"] }}</td></tr>
-<tr><td>Name</td><td>{{ version["name"] or package["name"] }}</td></tr>
-<tr><td>Project site</td><td>
-{% set url = version["url"] or package["url"] %}
-{% if url %}
-<a href="{{ url }}" target="_blank">{{ url }}</a>
-{% endif %}
-</td></tr>
-<tr><td>Version</td><td>{{ version["version"] }}</td></tr>
-<tr><td>Upload date</td><td>{{ version["upload-date"] }}</td></tr>
-<tr><td>MD5 (partial)</td><td>{{ version["md5sum-partial"] }}</td></tr>
-<tr><td>License</td><td>{{ version["license"] }}</td></tr>
-<tr><td>Download availability</td><td>{{ version["availability"] }}</td></tr>
-<tr><td>Download</td>
-{% if version["download-url"] %}
-    <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-{% else %}
-    <td>Not available</td>
-{% endif %}
-</tr>
-<tr><td>Compatibility</td><td><ul>
-{% for compat in version["compatibility"] %}
-    <li>{{ compat["name"] }}: {{ compat["conditions"] | join(", ") }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Dependencies</td><td><ul>
-{% for dep in version["dependencies"] %}
-    <li><a href="/package/{{ dep["content-type"] }}/{{ dep["unique-id"] }}/{{ dep["upload-date"] }}" target="_blank">{{ dep["name"] }} {{ dep["version"] }}</a></li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Tags</td><td><ul>
-{% set tags = version["tags"] or package["tags"] %}
-{% for t in tags %}
-    <li>{{ t }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Authors</td><td><ul>
-{% for a in package["authors"] %}
-    <li>{{ a["display-name"] }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Description</td><td>
+<tbody>
+    <tr><th>Content Id</th><td>{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["md5sum-partial"] }}</td></tr>
+    <tr><th>Name</th><td>{{ version["name"] or package["name"] }}</td></tr>
+    <tr><th>Project site</th><td>
+    {% set url = version["url"] or package["url"] %}
+    {% if url %}
+        <a href="{{ url }}" target="_blank">{{ url }}</a>
+    {% endif %}
+    </td></tr>
+    <tr><th>Version</th><td>{{ version["version"] }}</td></tr>
+    <tr><th>Upload date</th><td>{{ version["upload-date"] }}</td></tr>
+    <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
+    <tr><th>License</th><td>{{ version["license"] }}</td></tr>
+    <tr><th>Download availability</th><td>{{ version["availability"] }}</td></tr>
+    <tr><th>Download</th>
+    {% if version["download-url"] %}
+        <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
+    {% else %}
+        <td>Not available</td>
+    {% endif %}
+    </tr>
+    <tr><th>Compatibility</th><td>
+        <ul>
+        {% for compat in version["compatibility"] %}
+            <li>{{ compat["name"] }}: {{ compat["conditions"] | join(", ") }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Dependencies</th><td>
+        <ul>
+        {% for dep in version["dependencies"] %}
+           <li><a href="/package/{{ dep["content-type"] }}/{{ dep["unique-id"] }}/{{ dep["upload-date"] }}" target="_blank">{{ dep["name"] }} {{ dep["version"] }}</a></li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Tags</th><td>
+        <ul>
+        {% set tags = version["tags"] or package["tags"] %}
+        {% for t in tags %}
+            <li>{{ t }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Authors</th><td>
+        <ul>
+        {% for a in package["authors"] %}
+            <li>{{ a["display-name"] }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Description</th><td>
     {% for l in (version["description"] or package["description"]).splitlines() %}
-    {{ l }}<br/>
+        {{ l }}<br/>
     {% endfor %}
-</td></tr>
+    </td></tr>
+</tbody>
 </table>
 
 {% endblock %}

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -15,52 +15,62 @@
 {% endif %}
 
 <table>
-<tr><td>Content type</td><td>{{ package["content-type"] }}</td></tr>
-<tr><td>Content Id</td><td>{{ package["unique-id"] }}</td></tr>
-<tr><td>Name</td><td>{{ package["name"] }}</td></tr>
-<tr><td>Project site</td><td>
-{% if package["url"] %}
-<a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
-{% endif %}
-</td></tr>
-<tr><td>Tags</td><td><ul>
-{% for t in package["tags"] %}
-    <li>{{ t }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Authors</td><td><ul>
-{% for a in package["authors"] %}
-    <li>{{ a["display-name"] }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Description</td><td>
-    {% for l in package["description"].splitlines() %}
-    {{ l }}<br/>
+<tbody>
+    <tr><th>Content type</th><td>{{ package["content-type"] }}</td></tr>
+    <tr><th>Content Id</th><td>{{ package["unique-id"] }}</td></tr>
+    <tr><th>Name</td><th>{{ package["name"] }}</td></tr>
+    <tr><th>Project site</th><td>
+    {% if package["url"] %}
+       <a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
+    {% endif %}
+    </td></tr>
+    <tr><th>Tags</th><td>
+        <ul>
+    {% for t in package["tags"] %}
+             <li>{{ t }}</li>
     {% endfor %}
-</td></tr>
+        </ul>
+    </td></tr>
+    <tr><th>Authors</th><td>
+        <ul>
+    {% for a in package["authors"] %}
+            <li>{{ a["display-name"] }}</li>
+    {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Description</th><td>
+    {% for l in package["description"].splitlines() %}
+        {{ l }}<br/>
+    {% endfor %}
+    </td></tr>
+</tbody>
 </table>
 
 <table>
-<tr>
-    <th>Version</th>
-    <th>Upload date</th>
-    <th>MD5 (partial)</th>
-    <th>License</th>
-    <th>Download</th>
-</tr>
+<thead>
+    <tr>
+        <th>Version</th>
+        <th>Upload date</th>
+        <th>MD5 (partial)</th>
+        <th>License</th>
+        <th>Download</th>
+    </tr>
+</thead>
+<tbody>
 {% for version in package["versions"] %}
-<tr>
-    <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}">{{ version["version"] }}</a></td>
-    <td>{{ version["upload-date"] }}</td>
-    <td>{{ version["md5sum-partial"] }}</td>
-    <td>{{ version["license"] }}</td>
-    {% if version["download-url"] %}
-        <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-    {% else %}
-        <td>Not available</td>
-    {% endif %}
-</tr>
+    <tr>
+        <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}">{{ version["version"] }}</a></td>
+        <td>{{ version["upload-date"] }}</td>
+        <td>{{ version["md5sum-partial"] }}</td>
+        <td>{{ version["license"] }}</td>
+        {% if version["download-url"] %}
+            <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
+        {% else %}
+            <td>Not available</td>
+        {% endif %}
+    </tr>
 {% endfor %}
+</tbody>
 </table>
 
 {% endblock %}

--- a/webclient/templates/package_list.html
+++ b/webclient/templates/package_list.html
@@ -7,38 +7,42 @@
 {% block content %}
 
 <table>
-<tr>
-    <th>Id</th>
-    <th>Name</th>
-    <th>Project site</th>
-    <th>Latest version</th>
-    <th>Upload date</th>
-    <th>License</th>
-    <th>Download</th>
-</tr>
+<thead>
+    <tr>
+        <th>Id</th>
+        <th>Name</th>
+        <th>Project site</th>
+        <th>Latest version</th>
+        <th>Upload date</th>
+        <th>License</th>
+        <th>Download</th>
+    </tr>
+</thead>
+<tbody>
 {% for package in packages %}
-<tr>
-    <td>{{ package["unique-id"] }}</td>
-    <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ package["name"] }}</a></td>
-    <td>
+    <tr>
+        <td>{{ package["unique-id"] }}</td>
+        <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ package["name"] }}</a></td>
+        <td>
         {% if package["url"] %}
-        <a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
+            <a href="{{ package["url"] }}" target="_blank">{{ package["url"] }}</a>
         {% endif %}
-    </td>
-    {% if package["latest"] %}
-        <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ package["latest"]["upload-date"] }}">{{ package["latest"]["version"] }}</a></td>
-        <td>{{ package["latest"]["upload-date"] }}</td>
-        <td>{{ package["latest"]["license"] }}</td>
-        {% if package["latest"]["download-url"] %}
-            <td><a href="{{ package["latest"]["download-url"] }}">{{ (package["latest"]["filesize"] | int) // 1024 }} kB</a></td>
+        </td>
+        {% if package["latest"] %}
+            <td><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ package["latest"]["upload-date"] }}">{{ package["latest"]["version"] }}</a></td>
+            <td>{{ package["latest"]["upload-date"] }}</td>
+            <td>{{ package["latest"]["license"] }}</td>
+            {% if package["latest"]["download-url"] %}
+                <td><a href="{{ package["latest"]["download-url"] }}">{{ (package["latest"]["filesize"] | int) // 1024 }} kB</a></td>
+            {% else %}
+                <td>Not available</td>
+            {% endif %}
         {% else %}
-            <td>Not available</td>
+            <td></td><td></td><td></td><td>Not available</td>
         {% endif %}
-    {% else %}
-        <td></td><td></td><td></td><td>Not available</td>
-    {% endif %}
-</tr>
+    </tr>
 {% endfor %}
+</tbody>
 </table>
 
 {% endblock %}

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -17,51 +17,61 @@
 <p><b> There is a newer version of this content available. Please use <a href="/package/{{ latest["content-type"] }}/{{ latest["unique-id"] }}/{{ latest["upload-date"] }}">version {{ latest["version"] }}</a> for new games. </b></p>
 {% endif %}
 <table>
-<tr><td>Content Id</td><td>{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["md5sum-partial"] }}</td></tr>
-<tr><td>Name</td><td>{{ version["name"] or package["name"] }}</td></tr>
-<tr><td>Project site</td><td>
-{% set url = version["url"] or package["url"] %}
-{% if url %}
-<a href="{{ url }}" target="_blank">{{ url }}</a>
-{% endif %}
-</td></tr>
-<tr><td>Version</td><td>{{ version["version"] }}</td></tr>
-<tr><td>Upload date</td><td>{{ version["upload-date"] }}</td></tr>
-<tr><td>MD5 (partial)</td><td>{{ version["md5sum-partial"] }}</td></tr>
-<tr><td>License</td><td>{{ version["license"] }}</td></tr>
-<tr><td>Download</td>
-{% if version["download-url"] %}
-    <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-{% else %}
-    <td>Not available</td>
-{% endif %}
-</tr>
-<tr><td>Compatibility</td><td><ul>
-{% for compat in version["compatibility"] %}
-    <li>{{ compat["name"] }}: {{ compat["conditions"] | join(", ") }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Dependencies</td><td><ul>
-{% for dep in version["dependencies"] %}
-    <li><a href="/package/{{ dep["content-type"] }}/{{ dep["unique-id"] }}/{{ dep["upload-date"] }}">{{ dep["name"] }} {{ dep["version"] }}</a></li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Tags</td><td><ul>
-{% set tags = version["tags"] or package["tags"] %}
-{% for t in tags %}
-    <li>{{ t }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Authors</td><td><ul>
-{% for a in package["authors"] %}
-    <li>{{ a["display-name"] }}</li>
-{% endfor %}
-</ul></td></tr>
-<tr><td>Description</td><td>
+<tbody>
+    <tr><th>Content Id</th><td>{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["md5sum-partial"] }}</td></tr>
+    <tr><th>Name</th><td>{{ version["name"] or package["name"] }}</td></tr>
+    <tr><th>Project site</th><td>
+    {% set url = version["url"] or package["url"] %}
+    {% if url %}
+        <a href="{{ url }}" target="_blank">{{ url }}</a>
+    {% endif %}
+    </td></tr>
+    <tr><th>Version</th><td>{{ version["version"] }}</td></tr>
+    <tr><th>Upload date</th><td>{{ version["upload-date"] }}</td></tr>
+    <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
+    <tr><th>License</th><td>{{ version["license"] }}</td></tr>
+    <tr><th>Download</th>
+    {% if version["download-url"] %}
+        <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
+    {% else %}
+        <td>Not available</td>
+    {% endif %}
+    </tr>
+    <tr><th>Compatibility</th><td>
+        <ul>
+        {% for compat in version["compatibility"] %}
+            <li>{{ compat["name"] }}: {{ compat["conditions"] | join(", ") }}</li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Dependencies</th><td>
+        <ul>
+        {% for dep in version["dependencies"] %}
+            <li><a href="/package/{{ dep["content-type"] }}/{{ dep["unique-id"] }}/{{ dep["upload-date"] }}">{{ dep["name"] }} {{ dep["version"] }}</a></li>
+        {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Tags</th><td>
+        <ul>
+    {% set tags = version["tags"] or package["tags"] %}
+    {% for t in tags %}
+            <li>{{ t }}</li>
+    {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Authors</th><td>
+        <ul>
+    {% for a in package["authors"] %}
+            <li>{{ a["display-name"] }}</li>
+    {% endfor %}
+        </ul>
+    </td></tr>
+    <tr><th>Description</th><td>
     {% for l in (version["description"] or package["description"]).splitlines() %}
     {{ l }}<br/>
     {% endfor %}
-</td></tr>
+    </td></tr>
+</tbody>
 </table>
 
 {% endblock %}


### PR DESCRIPTION
With exception of the tables in forms, which I plan to handle in a separate PR, every table got a meta structure of `tbody` elements and `thead`, where suitable. Additionally the naming fields of table rows changed from `td` to `th`.