### PR TITLE
Changes to the page header

### DIFF
--- a/webclient/templates/manager_package_edit.html
+++ b/webclient/templates/manager_package_edit.html
@@ -2,7 +2,7 @@
 {% block header %}
 <header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
-    <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+    <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/manager_package_info.html
+++ b/webclient/templates/manager_package_info.html
@@ -2,7 +2,7 @@
 {% block header %}
 <header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
-    <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+    <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/manager_version_edit.html
+++ b/webclient/templates/manager_version_edit.html
@@ -3,7 +3,7 @@
 {% block header %}
 <header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
-    <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+    <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -3,7 +3,7 @@
 {% block header %}
 <header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
-    <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+    <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -2,7 +2,7 @@
 {% block header %}
 <header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
-    <h3>{{ package["content-type"] }}/{{ package["unique-id"] }}</h3>
+    <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/tos-1.2.html
+++ b/webclient/templates/tos-1.2.html
@@ -2,7 +2,7 @@
 {% block header %}
 <header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
-    <h3>Version 1.2, 2010-01-26</h3>
+    <p>Version 1.2, 2010-01-26</p>
 </header>
 {% endblock %}
 {% block content %}

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -3,7 +3,7 @@
 {% block header %}
 <header>
     <h1><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
-    <h3>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</h3>
+    <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
 </header>
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
First change is to replace the `h3` in `header` with `p`. There are *for me* two arguments. First is, that one should not  skip heading levels (that would cause a change from `h1` followed by `h3` to `h1` followed by `h2`) and second (and IMHO more important), the information, stored in the `h3`, are no headings in itself. We can format the content also in paragraphs eye-catching if wished.

---

One additional issue. I made testing pages for several contents to be able to understand the desired HTML structure (i.e. loops here and there and the table structure especially of the manager_package_list.html with it's [many rowspans and colspans in the table header](https://github.com/OpenTTD/bananas-frontend-web/blob/master/webclient/templates/manager_package_list.html#L12)). Doing so, I came across the menu structure and the order of the main blocks (page header, menu, content). So I played around and came up with a first draft of a menu in a list structure (see therefore [this Gist](https://gist.github.com/auge8472/4c7967734b2a3465111c5eed4a693741)). During the tests I changed the order of the HTML-source from menu=>header=>content to header=>menu=>content. See therefore the creenshot and ignore the "Presented by BaNaNaS".

![bananas-menu-1](https://user-images.githubusercontent.com/1734660/79386377-548cdc80-7f6a-11ea-9ded-409fe92a1467.png)

If I want to change the order also in the code, I have to alter the position of `{% block header %}{% endblock %}` in the base.html, [havn't I](https://gist.github.com/auge8472/2c2c45db0592b3c4b2f2e5f44f4819fd) (file name should have been order.html)?

*Is this desirable at all?* If so, I would like to add this small additional change to *this* PR.
