### PR TITLE
A point to start

### DIFF
--- a/webclient/static/css/page.css
+++ b/webclient/static/css/page.css
@@ -1,0 +1,18 @@
+*, :before, :after {
+	box-sizing: border-box;
+}
+html, body {
+	margin: 0;
+	padding: 0;
+	background-color: #fff;
+	color: #000;
+	font-size: 1em;
+	font-family: sans-serif;
+}
+
+/* set common rules for the first level elements inside body (nav, header, main, footer) */
+body > * {
+	margin: 0;
+	padding: 0.25em 0.5em;
+	padding: 0.25rem 0.5rem;
+}

--- a/webclient/templates/base.html
+++ b/webclient/templates/base.html
@@ -26,7 +26,9 @@
     </td>
 </tr></table>
 
+<header>
 {% block header %}{% endblock %}
+</header>
 {% if messages %}
 <ul>
     {% for message in messages %}

--- a/webclient/templates/base.html
+++ b/webclient/templates/base.html
@@ -32,7 +32,7 @@
 </header>
 <main>
 {% if messages %}
-<ul>
+<ul id="system-notices">
     {% for message in messages %}
     <li>{{ message }}</li>
     {% endfor %}

--- a/webclient/templates/base.html
+++ b/webclient/templates/base.html
@@ -5,6 +5,7 @@
     <title>{% block title %}{% endblock %} - BaNaNaS - OpenTTD</title>
 </head>
 <body>
+<nav>
 <table><tr>
     <td><a href="/">BaNaNaS</a></td>
     <td><a href="/package/base-graphics">Base-Graphics</a><br/>
@@ -25,10 +26,11 @@
         {% endif %}
     </td>
 </tr></table>
-
+</nav>
 <header>
 {% block header %}{% endblock %}
 </header>
+<main>
 {% if messages %}
 <ul>
     {% for message in messages %}
@@ -37,5 +39,6 @@
 </ul>
 {% endif %}
 {% block content %}{% endblock %}
+</main>
 </body>
 </html>

--- a/webclient/templates/base.html
+++ b/webclient/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>{% block title %}{% endblock %} - BaNaNaS - OpenTTD</title>
+    <link rel="stylesheet" href="/static/css/page.css" />
 </head>
 <body>
 <nav>

--- a/webclient/templates/main.html
+++ b/webclient/templates/main.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}BaNaNaS{% endblock %}</h1>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_new_package.html
+++ b/webclient/templates/manager_new_package.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Upload new package{% endblock %}</h1>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_edit.html
+++ b/webclient/templates/manager_package_edit.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_info.html
+++ b/webclient/templates/manager_package_info.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_package_list.html
+++ b/webclient/templates/manager_package_list.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Awesome content by {{ session.display_name }}{% endblock %}</h1>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_version_edit.html
+++ b/webclient/templates/manager_version_edit.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
-<header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
-<header>
     <h1><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}{{ package["name"] }}{% endblock %}</h1>
     <p>{{ package["content-type"] }}/{{ package["unique-id"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/package_list.html
+++ b/webclient/templates/package_list.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}{{ content_type }}{% endblock %}</h1>
-</header>
 {% endblock %}
 {% block content %}
 

--- a/webclient/templates/tos-1.0.html
+++ b/webclient/templates/tos-1.0.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
-    <h3>Version 1.0, 2009-01-17</h3>
+    <p>Version 1.0, 2009-01-17</p>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.0.html
+++ b/webclient/templates/tos-1.0.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
     <h3>Version 1.0, 2009-01-17</h3>
-</header>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.1.html
+++ b/webclient/templates/tos-1.1.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
     <h3>Version 1.1, 2009-08-10</h3>
-</header>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.1.html
+++ b/webclient/templates/tos-1.1.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
-    <h3>Version 1.1, 2009-08-10</h3>
+    <p>Version 1.1, 2009-08-10</p>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.2.html
+++ b/webclient/templates/tos-1.2.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
     <p>Version 1.2, 2010-01-26</p>
-</header>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.3.html
+++ b/webclient/templates/tos-1.3.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
-    <h3>Version 1.3, 2020-04-19</h3>
+    <p>Version 1.3, 2020-04-19</p>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/tos-1.3.html
+++ b/webclient/templates/tos-1.3.html
@@ -1,9 +1,7 @@
 {% extends 'base.html' %}
 {% block header %}
-<header>
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
     <h3>Version 1.3, 2020-04-19</h3>
-</header>
 {% endblock %}
 {% block content %}
 <ol>

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %}
 {% block title %}{{ version["name"] or package["name"] }} {{ version["version"] }}{% endblock %}
 {% block header %}
-<header>
     <h1><a href="/package/{{ package["content-type"] }}/{{ package["unique-id"] }}">{{ version["name"] or package["name"] }}</a> {{ version["version"] }}</h1>
     <p>{{ version["content-type"] }}/{{ version["unique-id"] }}/{{ version["upload-date"] }}</p>
-</header>
 {% endblock %}
 {% block content %}
 


### PR DESCRIPTION
This is a collection of further base changes and corrections in preparation for the work on styling.

- move the `<header>` tags from the individual templates to base.html (sorry for the previous, inappropriate solution)
- add `<nav>` and `<main>` to base.html
- set an ID (`system-notices`) for the list template for system messages in base.html
- replace `<h3>` with `<p>` in the new pages (tos versions 1.0, 1.1 and 1.3)
- create `page.css` with the first, rudimentary rules and link the CSS-file in base.css

With these changes, we can address all elements with specific and different approaches for the different main sections of the pages (`<nav>`, `<header>`, `<main>` sections).