### PR TITLE
Format the elements in the page header

### DIFF
--- a/webclient/static/css/page.css
+++ b/webclient/static/css/page.css
@@ -16,3 +16,19 @@ body > * {
 	padding: 0.25em 0.5em;
 	padding: 0.25rem 0.5rem;
 }
+
+/* page header and its descendant elements */
+body > header > * {
+	margin: 0.5em 0;
+	margin: 0.5rem 0;
+	padding: 0;
+}
+body > header > *:last-child {
+	margin-bottom: 0;
+}
+body > header h1 {
+	font-size: 1.5em;
+}
+body > header p {
+	font-weight: bold;
+}

--- a/webclient/static/css/page.css
+++ b/webclient/static/css/page.css
@@ -32,3 +32,12 @@ body > header h1 {
 body > header p {
 	font-weight: bold;
 }
+
+@media screen and (min-width: 40em) {
+	/* set common rules for the first level elements inside body (nav, header, main, footer) */
+	body > * {
+		padding: 0.25em 1em;
+		padding: 0.25rem 1rem;
+	}
+}
+


### PR DESCRIPTION
Add general rules for all direct childs of the page header (`body > header`), font size rule for `h1` and bold font weight for the optional `p`.

Additionally I added a commit go provide a bigger left and right padding for the direct childs of `body` on viewport widths of 40em or larger.