### PR TITLE
Add: introduce more clear guidelines in the use of GPL licenses

### DIFF
--- a/webclient/pages/static.py
+++ b/webclient/pages/static.py
@@ -11,6 +11,7 @@ _tos_versions = {
     "1.1": "tos-1.1.html",
     "1.2": "tos-1.2.html",
     "1.3": "tos-1.3.html",
+    "1.4": "tos-1.4.html",
 }
 
 
@@ -33,7 +34,7 @@ def user_migration():
 
 @app.route("/manager/tos")
 def tos_latest():
-    return redirect("tos", version="1.3")
+    return redirect("tos", version="1.4")
 
 
 @app.route("/manager/tos/<version>")

--- a/webclient/templates/manager_new_package.html
+++ b/webclient/templates/manager_new_package.html
@@ -8,7 +8,7 @@
 <form method="post">
 <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
 <h3>Step 1: Terms of service</h3>
-<p>Please read our <a href="/manager/tos" target="_blank">terms of service</a>. This is no lawyer blah-blah. This is a volunteer project, please do not try to cheat the system.</p>
+<p>Please read our <a href="/manager/tos" target="_blank">terms of service</a> (last updated 2020-11-01). This is no lawyer blah-blah. This is a volunteer project, please do not try to cheat the system.</p>
 <p>
     <input type="checkbox" name="tos" value="accepted" {% if accept_tos %} checked {% endif %}/>
     <label for="tos">I confirm that I am one of the authors, and I have read and understood the <a href="/manager/tos" target="_blank">terms of service</a></label>
@@ -64,6 +64,10 @@
     {% endfor %}
     </select>
     <p id="input-desc">Unsure which license to pick? <a href="https://www.tt-forums.net/viewtopic.php?f=68&amp;t=55814" target="_blank">Look here</a></p>
+    <p id="input-desc">
+        <b>Note</b>: if you pick GPL v2, GPL v3 or LGPL v2.1, you are obligated to also make your source code available.
+        Please make sure to link to your source code in "Project site", "Description" and/or uploaded README.
+    </p>
 </td></tr>
 <tr><th>Compatibility</th><td>
     <table>

--- a/webclient/templates/tos-1.4.html
+++ b/webclient/templates/tos-1.4.html
@@ -2,11 +2,17 @@
 {% extends 'base.html' %}
 {% block header %}
     <h1>{% block title %}Terms of Service{% endblock %}</h1>
-    <p>Version 1.3, 2020-04-27</p>
+    <p>Version 1.4, 2020-11-01</p>
 {% endblock %}
 {% block content %}
 <ol type="1">
-    <li>You will only upload content of which you are (one of) the original author(s).</li>
+    <li>You will only upload content that comply with the following:
+        <ol type="a">
+            <li>You will only upload content of which you are (one of) the author(s).</li>
+            <li>You will use a license that is compatible with all source material used.</li>
+            <li>If you use GPL v2, GPL v3 or LGPL v2.1 as license, you will supply a link to your source code in "Project site", "Description" and/or uploaded README.</li>
+        </ol>
+    </li>
     <li>You grant the OpenTTD team the rights to distribute the last version of your content from a central server. We will assign a globally unique identifier to each upload and everyone can download the content when they know that identifier.</li>
     <li>You grant the OpenTTD team to distribute your latest content via our website.</li>
     <li>You grant the OpenTTD team to retain older versions of your content for the purpose of loading save games with said older version.</li>

--- a/webclient/templates/tos-1.4.html
+++ b/webclient/templates/tos-1.4.html
@@ -1,0 +1,42 @@
+{% set selected_nav = "bananas" %}
+{% extends 'base.html' %}
+{% block header %}
+    <h1>{% block title %}Terms of Service{% endblock %}</h1>
+    <p>Version 1.3, 2020-04-27</p>
+{% endblock %}
+{% block content %}
+<ol type="1">
+    <li>You will only upload content of which you are (one of) the original author(s).</li>
+    <li>You grant the OpenTTD team the rights to distribute the last version of your content from a central server. We will assign a globally unique identifier to each upload and everyone can download the content when they know that identifier.</li>
+    <li>You grant the OpenTTD team to distribute your latest content via our website.</li>
+    <li>You grant the OpenTTD team to retain older versions of your content for the purpose of loading save games with said older version.</li>
+    <li>You grant the OpenTTD team the rights to distribute your content from a central server when specifically asked for it by its unique identifier and MD5 checksum. The origin of the unique identifier and MD5 checksum differs per type of content:
+        <ol type="a">
+            <li>Base graphics: unique identifier is constructed from the four character short name defined in the .obg file. The MD5 checksum is the exclusive or of the MD5 checksum of the 6 GRFs that are part of the graphics pack.</li>
+            <li>NewGRFs: unique identifier is constructed from the GRF ID. The MD5 checksum is the MD5 checksum of the .grf file.</li>
+            <li>AIs and AI Libraries: unique identifier is constructed from the four character short name defined in the info.nut. The MD5 checksum is the exclusive or of the MD5 checksums of all scripting files that are part of the AI or AI Library.</li>
+            <li>Heightmaps and scenarios: unique identifier is automatically generated when you upload the content. The MD5 checksum is the MD5 checksum of the scenario/heightmap.</li>
+            <li>Base sound: unique identifier is constructed from the four character short name defined in the .obs file. The MD5 checksum is the MD5 checksum of the cat file that is part of the sound pack.</li>
+            <li>Base music: unique identifier is constructed from the four character short name defined in the .obm file. The MD5 checksum is the exclusive or of MD5 checksum of the music files that are part of the music pack. If they are mentioned multiple times in the .obm file they are exclusive or-ed multiple times. </li>
+        </ol>
+    </li>
+    <li>You grant the OpenTTD team the rights to repackage your content before publishing it. The repackaging:
+        <ol type="a">
+            <li>keeps files called "readme", "license" and "changelog" with .txt as extension.</li>
+            <li>requires a "license.txt" file in the package file or requires that you selected a non-custom license when uploading the package. In the latter case that license will be added to the package.</li>
+            <li>(deleted)</li>
+            <li>requires exactly one .grf file in NewGRF packages.</li>
+            <li>requires exactly one .obg file and exactly six .grf files in Base graphics packages as named in the .obg file and with the same MD5 checksums as defined in the .obg file.</li>
+            <li>requires .nut files in AI and AI Library packages.</li>
+            <li>(deleted)</li>
+            <li>(deleted)</li>
+            <li>requires a "main.nut" and "info.nut" in AI packages.</li>
+            <li>requires a "main.nut" and "library.nut" in AI Library packages.</li>
+            <li>requires exactly one .scn file in Scenario packages.</li>
+            <li>requires exactly one .png file in Heightmap packages.</li>
+            <li>requires exactly one .obs file and exactly one .cat file in Base sound packages as named in the .obs file and with the same MD5 checksum as defined in the .obs file.</li>
+            <li>requires exactly one .obm file and a number of music files in Base music packages as named in the .obm file and with the same MD5 checksum as defined in the .obm file.</li>
+        </ol>
+    </li>
+</ol>
+{% endblock %}


### PR DESCRIPTION
Given the following scenario:
- Author A creates a GRF under GPL v2
- Author B picks up that work and extends on it
If user B wants to upload to BaNaNaS, the only way he can do that
is by complying to GPL v2. In order to be compliant, a link to
the source code has to be supplied. This commit makes it more
clear to the authors that this is expected of them.

This is not meant to protect OpenTTD, but more to be a good
neighbour and ensure authors are aware of the implications of
the license they used (to base their work on).

