### PR TITLE
Fix #123: The correct way to download content is via the OpenTTD client

### DIFF
--- a/webclient/templates/main.html
+++ b/webclient/templates/main.html
@@ -10,7 +10,7 @@
 <p> If you want to use BaNaNaS: </p>
 <ul>
 <li> This is a volunteer project. Do not litter. </li>
-<li> For downloading content, prefer using OpenTTD's build-in content downloader. But packages are also available for download on this page. </li>
+<li> For downloading content, please use OpenTTD's built-in content downloader. </li>
 <li> For uploading content: <ul>
     <li> Read our <a href="/manager/tos">terms of service</a>. This is no lawyer blah-blah. This is a volunteer project, please do not try to cheat the system. </li>
     <li> <a href="/login">Login via GitHub</a>. </li>


### PR DESCRIPTION
The website is for people to view, manage, and upload their content.