### PR TITLE
Fix: editing versions result in error due to missing region field

### DIFF
--- a/webclient/pages/version_info.py
+++ b/webclient/pages/version_info.py
@@ -205,8 +205,6 @@ def manager_version_edit(session, content_type, unique_id, upload_date):
         record_change_compatibility(changes, version, form)
         if not record_change_dependencies(changes, version, form, messages):
             valid_data = False
-        if not record_change_regions(changes, version, form.get("regions"), messages):
-            valid_data = False
         record_change_description(changes, version, form.get("description"))
 
         version.update(changes)


### PR DESCRIPTION
Regions are only expected on package-level, not version-level. This code is an old left-over from when it was also on version-level.