### PR TITLE
Fix #198: Remove useless "unique-id" query parameter

### DIFF
--- a/webclient/templates/manager_package_list.html
+++ b/webclient/templates/manager_package_list.html
@@ -51,7 +51,7 @@
         {% else %}
             <td></td><td></td>
         {% endif %}
-        <td><a href="/manager/new-package?unique-id={{ package["unique-id"] }}">Upload update</a></td>
+        <td><a href="/manager/new-package">Upload update</a></td>
     </tr>
 {% endfor %}
 </tbody>


### PR DESCRIPTION
As mentioned in #198, `The "unique-id" query parameter doesn't do anything, and is most likely a remnant from a past.`