### PR TITLE
Fix #227: limit the upload chunk-size, or Cloudflare will block the upload.

### DIFF
--- a/webclient/static/uploader.js
+++ b/webclient/static/uploader.js
@@ -113,6 +113,7 @@ function start_next_upload() {
         endpoint: tus_url,
         retryDelays: [0, 1000, 3000, 5000],
         removeFingerprintOnSuccess: true,
+        chunkSize: 50 * 1024 * 1024, /* Cloudflare limits to 100 MB */
         metadata: {
             "upload-token": upload_token,
             filename: upload_file.name


### PR DESCRIPTION
Currently neither TUS nor TUSD set an upload limit, so it will attempt an upload with a single request.
Other intermediates do not allow that.

So, set a limit in the TUS client.

Fixes #227