### PR TITLE
Fix: Improve consistency between manager and non-manager views

### DIFF
--- a/webclient/templates/manager_package_info.html
+++ b/webclient/templates/manager_package_info.html
@@ -81,7 +81,7 @@
         <th>Upload date</th>
         <th>MD5 (partial)</th>
         <th>License</th>
-        <th>Availability</th>
+        <th>Download availability</th>
         <th>Edit meta data</th>
     </tr>
 </thead>
@@ -92,7 +92,11 @@
         <td>{{ version["upload-date"] }}</td>
         <td>{{ version["md5sum-partial"] }}</td>
         <td>{{ version["license"] }}</td>
-        <td>{{ version["availability"] }}</td>
+        {% if version["availability"] == "new-games" %}
+            <td>Available ingame</td>
+        {% else %}
+            <td>Only for savegames</td>
+        {% endif %}
         <td><a href="/manager/{{ package["content-type"] }}/{{ package["unique-id"] }}/{{ version["upload-date"] }}/edit">Edit</a></td>
     </tr>
 {% endfor %}

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -40,7 +40,13 @@
     <tr><th>Upload date</th><td>{{ version["upload-date"] }}</td></tr>
     <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
     <tr><th>License</th><td>{{ version["license"] }}</td></tr>
-    <tr><th>Download availability</th><td>{{ version["availability"] }}</td></tr>
+    <tr><th>Download availability</th>
+    {% if version["availability"] == "new-games" %}
+        <td>Available ingame</td>
+    {% else %}
+        <td>Only for savegames</td>
+    {% endif %}
+    </tr>
     <tr><th>Compatibility</th><td>
         <ul class="compatibility">
         {% for c in compatibility %}

--- a/webclient/templates/manager_version_info.html
+++ b/webclient/templates/manager_version_info.html
@@ -41,13 +41,6 @@
     <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
     <tr><th>License</th><td>{{ version["license"] }}</td></tr>
     <tr><th>Download availability</th><td>{{ version["availability"] }}</td></tr>
-    <tr><th>Download</th>
-    {% if version["download-url"] %}
-        <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-    {% else %}
-        <td>Not available</td>
-    {% endif %}
-    </tr>
     <tr><th>Compatibility</th><td>
         <ul class="compatibility">
         {% for c in compatibility %}

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -94,9 +94,7 @@
         <td>{{ version["upload-date"] }}</td>
         <td>{{ version["md5sum-partial"] }}</td>
         <td>{{ version["license"] }}</td>
-        {% if version["download-url"] %}
-            <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-        {% elif version["availability"] == "new-games" %}
+        {% if version["availability"] == "new-games" %}
             <td>Available ingame</td>
         {% else %}
             <td>Only for savegames</td>

--- a/webclient/templates/package_info.html
+++ b/webclient/templates/package_info.html
@@ -84,7 +84,7 @@
         <th>Upload date</th>
         <th>MD5 (partial)</th>
         <th>License</th>
-        <th>Download</th>
+        <th>Download availability</th>
     </tr>
 </thead>
 <tbody>

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -70,7 +70,7 @@
     <tr><th>Upload date</th><td>{{ version["upload-date"] }}</td></tr>
     <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
     <tr><th>License</th><td>{{ version["license"] }}</td></tr>
-    <tr><th>Download</th>
+    <tr><th>Download availability</th>
     {% if version["availability"] == "new-games" %}
         <td>Available ingame</td>
     {% else %}

--- a/webclient/templates/version_info.html
+++ b/webclient/templates/version_info.html
@@ -71,9 +71,7 @@
     <tr><th>MD5 (partial)</th><td>{{ version["md5sum-partial"] }}</td></tr>
     <tr><th>License</th><td>{{ version["license"] }}</td></tr>
     <tr><th>Download</th>
-    {% if version["download-url"] %}
-        <td><a href="{{ version["download-url"] }}">{{ (version["filesize"] | int) // 1024 }} kB</a></td>
-    {% elif version["availability"] == "new-games" %}
+    {% if version["availability"] == "new-games" %}
         <td>Available ingame</td>
     {% else %}
         <td>Only for savegames</td>


### PR DESCRIPTION
Non manager views merge `availability` and `download-url` to create "Download" field, while manager views show them separately as "Download availability" and "Download" (and as `download-url` is never set it's always "Not available").
This can be confusing.
So split `availability` and `download-url` handling in non manager views.

Also fully hide the "Download" field in "Not available" case.